### PR TITLE
feat(Datastore): Add credentials wrapper support in DatastoreClient

### DIFF
--- a/Datastore/src/DatastoreClient.php
+++ b/Datastore/src/DatastoreClient.php
@@ -182,6 +182,11 @@ class DatastoreClient
             ],
         ];
         $config = $this->buildClientOptions($config);
+        $config['credentials'] = $this->createCredentialsWrapper(
+            $config['credentials'],
+            $config['credentialsConfig'],
+            $config['universeDomain'],
+        );
 
         $config = $this->configureAuthentication($config);
         $this->connection = $connectionType === 'grpc'


### PR DESCRIPTION
Add credentials config support in `GooglCloud\Datastore\DatastoreClient`
